### PR TITLE
[FIX] give all arguments to Editor to be able to use them

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,7 +28,7 @@ extended by other plugins that provide support for specific editors.
 # or merged change.
 # ------------------------------------------------------------------------------
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 
 # --- Dependencies -------------------------------------------------------------
 # List other odev plugins from which this current plugin depends.

--- a/commands/code.py
+++ b/commands/code.py
@@ -21,7 +21,7 @@ class EditorCommand(DatabaseOrRepositoryCommand):
         editor_class = Editor.__subclasses__()[0]
 
         try:
-            editor = editor_class(self._database, self.args.repository)
+            editor = editor_class(self._database, self.args)
         except ValueError as error:
             raise self.error(str(error)) from error
 

--- a/common/editor.py
+++ b/common/editor.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from argparse import Namespace
 from pathlib import Path
 from typing import ClassVar, Optional
 
@@ -20,16 +21,20 @@ class Editor(ABC):
     _display_name: ClassVar[str]
     """Display name of the code editor."""
 
-    def __init__(self, database: DummyDatabase | LocalDatabase, repository: Optional[str] = None):
+    def __init__(self, database: DummyDatabase | LocalDatabase, cmd_args: Namespace):
         """Initialize the editor with a database or repository.
         :param database: The database linked to the project to open in the editor.
-        :param repository: The repository to open in the editor.
+        :param cmd_args: Arguments from the `Editor` command.
         """
+        repository: Optional[str] = cmd_args.repository
         if isinstance(database, LocalDatabase) and repository is not None:
             raise ValueError("Cannot provide both database and repository")
 
         self.database = database
         """The database linked to the project to open in the editor."""
+
+        self.cmd_args = cmd_args
+        """The command arguments."""
 
         self.repository: str = "odoo/odoo"
         """The repository to open in the editor."""


### PR DESCRIPTION
## Description

Before this commit:
Overriding the `EditorCommand` to add new parameters/arguments to the command would work. But it would not be accessible from `Editor` class as only the `repository` was given from the args

After this commit:
Forward to the `Editor` all commands arguments

! This is potentially unstable if `__init__` is overridden by `Editor` subclasses

## Linked Issues

Link the issues that this PR solves, if any: Nope!

## Compliance

- [ ] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
