### PR TITLE
[IMP] Open directories for an Odoo version

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,7 +28,7 @@ extended by other plugins that provide support for specific editors.
 # or merged change.
 # ------------------------------------------------------------------------------
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 
 # --- Dependencies -------------------------------------------------------------
 # List other odev plugins from which this current plugin depends.

--- a/commands/code.py
+++ b/commands/code.py
@@ -1,4 +1,6 @@
+from odev.common import args
 from odev.common.commands import DatabaseOrRepositoryCommand
+from odev.common.version import OdooVersion
 
 from odev.plugins.odev_plugin_editor_base.common.editor import Editor
 
@@ -9,6 +11,21 @@ class EditorCommand(DatabaseOrRepositoryCommand):
     """
 
     _name = "code"
+
+    _database_allowed_platforms = ["local"]
+
+    _exclusive_arguments = [("database", "version")]
+
+    version = args.String(
+        aliases=["-V", "--version"],
+        description="Odoo version to open a workspace for.",
+    )
+
+    @classmethod
+    def prepare_command(cls, *args, **kwargs) -> None:
+        super().prepare_command(*args, **kwargs)
+        cls.remove_argument("platform")
+        cls.remove_argument("branch")
 
     def run(self):
         editor_subclasses = Editor.__subclasses__()
@@ -21,7 +38,11 @@ class EditorCommand(DatabaseOrRepositoryCommand):
         editor_class = Editor.__subclasses__()[0]
 
         try:
-            editor = editor_class(self._database, self.args.repository)
+            editor = editor_class(
+                self._database,
+                self.args.repository,
+                OdooVersion(self.args.version) if self.args.version else None,
+            )
         except ValueError as error:
             raise self.error(str(error)) from error
 

--- a/common/editor.py
+++ b/common/editor.py
@@ -6,6 +6,7 @@ from odev.common import bash
 from odev.common.connectors import GitConnector
 from odev.common.databases import DummyDatabase, LocalDatabase, Repository
 from odev.common.logging import logging
+from odev.common.version import OdooVersion
 
 
 logger = logging.getLogger(__name__)
@@ -20,19 +21,24 @@ class Editor(ABC):
     _display_name: ClassVar[str]
     """Display name of the code editor."""
 
-    def __init__(self, database: DummyDatabase | LocalDatabase, repository: Optional[str] = None):
+    def __init__(
+        self,
+        database: DummyDatabase | LocalDatabase,
+        repository: Optional[str] = None,
+        version: Optional[OdooVersion] = None,
+    ):
         """Initialize the editor with a database or repository.
         :param database: The database linked to the project to open in the editor.
         :param repository: The repository to open in the editor.
         """
-        if isinstance(database, LocalDatabase) and repository is not None:
-            raise ValueError("Cannot provide both database and repository")
-
         self.database = database
         """The database linked to the project to open in the editor."""
 
         self.repository: str = "odoo/odoo"
         """The repository to open in the editor."""
+
+        self.version = version
+        """The Odoo version to open in the editor."""
 
         if repository:
             self.repository = repository
@@ -46,6 +52,11 @@ class Editor(ABC):
             logger.warning(f"No repository associated with local database {database.name!r}")
 
     @property
+    def display_name(self) -> str:
+        """The display name of the editor."""
+        return self._display_name
+
+    @property
     def git(self) -> GitConnector:
         """The Git connector for the project."""
         return GitConnector(self.repository)
@@ -53,7 +64,7 @@ class Editor(ABC):
     @property
     def path(self) -> Path:
         """The path to the project."""
-        return self.git.path
+        return self.git.path if isinstance(self.database, LocalDatabase) else Path("~/odev/workspaces/").expanduser()
 
     @property
     def command(self) -> str:
@@ -79,7 +90,8 @@ class Editor(ABC):
     def open(self):
         """Open the editor with the project loaded."""
         self.configure()
-        logger.info(f"Opening project {self.repository!r} in {self._display_name}")
+        project = f"project {self.repository!r}" if not self.version else f"Odoo {self.version}"
+        logger.info(f"Opening {project} in {self.display_name}")
 
         if not self.git.exists:
             logger.warning(f"Local repository {self.path} does not exist, opening the editor may fail")


### PR DESCRIPTION
## Description

Add support for opening a workspace containing standard Odoo modules onlyu, without the need for a linked database or repository.

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [] I have incremented the version number according the [versioning guide](../x../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
