### PR TITLE
[IMP] code: save the repository given on the command line

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,7 +28,7 @@ extended by other plugins that provide support for specific editors.
 # or merged change.
 # ------------------------------------------------------------------------------
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 # --- Dependencies -------------------------------------------------------------
 # List other odev plugins from which this current plugin depends.

--- a/commands/code.py
+++ b/commands/code.py
@@ -1,8 +1,13 @@
 from odev.common import args
 from odev.common.commands import DatabaseOrRepositoryCommand
+from odev.common.databases import LocalDatabase
+from odev.common.logging import logging
 from odev.common.version import OdooVersion
 
 from odev.plugins.odev_plugin_editor_base.common.editor import Editor
+
+
+logger = logging.getLogger(__name__)
 
 
 class EditorCommand(DatabaseOrRepositoryCommand):
@@ -36,6 +41,7 @@ class EditorCommand(DatabaseOrRepositoryCommand):
             raise self.error("Multiple editor plugins are activated, please deactivate all but one and retry")
 
         editor_class = Editor.__subclasses__()[0]
+        self.link_repository()
 
         try:
             editor = editor_class(
@@ -47,3 +53,19 @@ class EditorCommand(DatabaseOrRepositoryCommand):
             raise self.error(str(error)) from error
 
         editor.open()
+
+    def link_repository(self) -> None:
+        """Save the repository given on the command line as the one linked to the database.
+
+        Passing a repository used to apply to that single invocation only, so the next `odev code`
+        on the same database had to be given the repository again. The link is now persisted, which
+        is also what makes the database usable with the other commands relying on it.
+        """
+        if not isinstance(self._database, LocalDatabase) or not self.args.repository:
+            return
+
+        previous = self._database.repository
+        repository = self._database.link_repository(self.args.repository)
+
+        if repository is not None and repository != previous:
+            logger.info(f"Linked database {self._database.name!r} to repository {repository.full_name!r}")


### PR DESCRIPTION
## Description

`odev code <database> <repository>` opened the project for that repository but did not record it, so
the next `odev code <database>` had lost the link and had to be given the repository again. That
invocation is what odoo-odev/odev#101 reports; the error the issue was filed for is already gone,
removed by abd6288, and what is left is the missing persistence.

The repository is now linked to the database through `LocalDatabase.link_repository`, the same entry
point `odev database --set-repo` uses, so it is normalized and stored once — repository names, HTTPS
and SSH URLs and paths to local clones all end up as `organization/repository` — and every command
relying on the link picks it up. `Editor.__init__` still receives the same argument and behaves
identically.

### Note for reviewers

**Merge odoo-odev/odev#107 first.** It adds `LocalDatabase.link_repository`, and nothing here
enforces that: the plugin declares no dependency and pins no core version, so on an older odev this
would raise `AttributeError` the first time a repository is passed. Requires odev 4.30.0.

No test is added because this repository has no test suite yet — `tests/` is empty. The behaviour is
covered on the core side, where `link_repository` is tested against names, HTTPS and SSH URLs and
against a database that has no row in the data store.

## Linked Issues

- closes odoo-odev/odev#101

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [ ] I have added or modified unit tests where necessary — this repository has no test suite
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8csZBrrBYp8oqH5paxTAm
